### PR TITLE
Fixed scale bug

### DIFF
--- a/Classes/KLNoteViewController.m
+++ b/Classes/KLNoteViewController.m
@@ -121,7 +121,7 @@
     CGFloat originOffset = 0;
     for (int i = 0; i < index; i ++) {
         CGFloat scalingFactor = [self scalingFactorForIndex: i];
-        NSLog(@"%@", controllerCard.navigationController.navigationBar);
+//        NSLog(@"%@", controllerCard.navigationController.navigationBar);
         originOffset += scalingFactor * controllerCard.navigationController.navigationBar.frame.size.height * self.cardNavigationBarOverlap;
     }
     
@@ -328,7 +328,7 @@
         index = _index;
         originY = [noteView defaultVerticalOriginForControllerCard:self
                                                            atIndex: index];
-        [self setFrame: self.navigationController.view.bounds];
+        [self setFrame: noteView.view.bounds];
 
         //Initialize the view's properties
         [self setAutoresizesSubviews:YES];
@@ -481,9 +481,20 @@
     if (animated) {
         [UIView animateWithDuration:self.noteViewController.cardAnimationDuration animations:^{
             [self setState:state animated:NO];
+        } completion:^(BOOL finished) {
+            if (state == KLControllerCardStateFullScreen) {
+                // Fix scaling bug when expand to full size
+                self.frame = self.noteViewController.view.bounds;
+                self.navigationController.view.frame = self.frame;
+                self.navigationController.view.layer.cornerRadius = 0;
+            }
         }];
         return;
     }
+    
+    // Set corner radius
+    [self.navigationController.view.layer setCornerRadius: self.noteViewController.cardCornerRadius];    
+    
     //Full Screen State
     if (state == KLControllerCardStateFullScreen) {
         [self expandCardToFullSize: animated];


### PR DESCRIPTION
Fixed #12 issue

After investigation and creating new blank sample project replicating KLNoteViewController view hierarchy to reproduce the issue with KL.

I am able to found out the problem was the scaling issue (probably OS bug).

The problem was after you scale down below 1, for example to 0.8:0.8 and make it back to scale 1:1 after some delay the bug will occurs.

The CGRect frame value was correct but it doesn't show so when displayed, so you have to explicitly set the frame once again to make it work like it should.
