### PR TITLE
Add a `cardNavigationBarClass` configuration option

### DIFF
--- a/Classes/KLNoteViewController.h
+++ b/Classes/KLNoteViewController.h
@@ -62,6 +62,9 @@ typedef UInt32 KLControllerCardPanGestureScope;
 @property (nonatomic, assign) id<KLNoteViewControllerDataSource> dataSource;
 @property (nonatomic, assign) id<KLNoteViewControllerDelegate> delegate;
 
+//Navigation bar properties
+@property (nonatomic, strong) Class cardNavigationBarClass; //Use a custom class for the card navigation bar
+
 //Layout properties
 @property (nonatomic) CGFloat cardMinimizedScalingFactor;   //Amount to shrink each card from the previous one
 @property (nonatomic) CGFloat cardMaximizedScalingFactor;   //Maximum a card can be scaled to

--- a/Classes/KLNoteViewController.m
+++ b/Classes/KLNoteViewController.m
@@ -71,6 +71,8 @@
 }
 
 - (void)configureDefaultSettings {
+    self.cardNavigationBarClass = [UINavigationBar class];
+    
     self.cardMinimizedScalingFactor = kDefaultMinimizedScalingFactor;
     self.cardMaximizedScalingFactor = kDefaultMaximizedScalingFactor;
     self.cardNavigationBarOverlap = kDefaultNavigationBarOverlap;
@@ -143,7 +145,9 @@
     for (NSInteger count = 0; count < totalCards; count++) {
         UIViewController* viewController = [self noteView:self viewControllerForRowAtIndexPath:[NSIndexPath indexPathForRow:count inSection:0]];
         
-        UINavigationController* navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+        UINavigationController* navigationController = [[UINavigationController alloc] initWithNavigationBarClass:self.cardNavigationBarClass
+                                                                                                     toolbarClass:[UIToolbar class]];
+        [navigationController pushViewController:viewController animated:NO];
         
         KLControllerCard* noteContainer = [[KLControllerCard alloc] initWithNoteViewController: self
                                                                                     navigationController: navigationController


### PR DESCRIPTION
Again me with a configuration option ^^

Apple introduce in iOS5 `initWithNavigationBarClass:toolbarClass:`, a new `UINavigationController` method to properly customize the navigation bar used. 

I think it's important that we can control this aspect of the design. I needed that, to achieve taller cards, like those one.

![Capture d e cran du Simulateur iOS 16 mars 2013 01 33 36](https://f.cloud.github.com/assets/328718/266120/2eead1cc-8dd1-11e2-95c2-51e703905cbe.png)
